### PR TITLE
Update expand-logarithms.md

### DIFF
--- a/expand-logarithms.md
+++ b/expand-logarithms.md
@@ -52,3 +52,14 @@
 </details>
 
 ---
+
+###### 6. Expand log<sub>a</sub>x / log<sub>a</sub>b
+
+<details><summary>Click the arrow for the answer.</summary>
+<p>
+  
+  ##### Answer: log<sub>b</sub>x
+</p>
+</details>
+
+---


### PR DESCRIPTION
Added the Change of base formula where Log_b (x) = Log_a (x) / Log_a (b). I used the instruction 'Expand' to keep in line with the document, but perhaps  'Simplify' might be better for this one.

Refer to khan academy for justification (though not a formal proof) https://www.khanacademy.org/math/algebra2/x2ec2f6f830c9fb89:logs/x2ec2f6f830c9fb89:change-of-base/a/logarithm-change-of-base-rule-intro